### PR TITLE
Load recording name, save with livedata.mat and use it in figure title

### DIFF
--- a/function_library/TobiiGlassesRecordings/getTobiiDataFromGlasses.m
+++ b/function_library/TobiiGlassesRecordings/getTobiiDataFromGlasses.m
@@ -2,7 +2,7 @@ function data = getTobiiDataFromGlasses(recordingDir,qDEBUG)
 
 % set file format version. cache files older than this are overwritten with
 % a newly generated cache file
-fileVersion = 4;
+fileVersion = 5;
 
 qGenCacheFile = ~exist(fullfile(recordingDir,'livedata.mat'),'file');
 if ~qGenCacheFile
@@ -330,6 +330,7 @@ if qGenCacheFile
     
     % 13 store to cache file
     data.name           = participant.pa_info.Name;
+    data.recname        = recording.rec_info.Name;
     data.fileVersion    = fileVersion;
     save(fullfile(recordingDir,'livedata.mat'),'-struct','data');
 else

--- a/glassesViewer.m
+++ b/glassesViewer.m
@@ -69,7 +69,7 @@ hm.UserData.time.mainTimer      = timer('Period', hm.UserData.time.tickPeriod, '
 hm.UserData.data = getTobiiDataFromGlasses(filedir,qDEBUG);
 hm.UserData.ui.haveEyeVideo = isfield(hm.UserData.data.videoSync,'eye');
 % update figure title
-hm.Name = [hm.Name ' (' hm.UserData.data.name ')'];
+hm.Name = [hm.Name ' (' hm.UserData.data.name '-' hm.UserData.data.recname ')'];
 
 
 %% setup data axes


### PR DESCRIPTION
Figure title only used participant name, this is confusing if more recordings are made with the same participant. Recording name is now loaded and saved with livedata.mat. Fileversion is changed to 5, so that existing .mat files are rebuilt.